### PR TITLE
fix(template): rename tache technique template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tache-technique.yml
+++ b/.github/ISSUE_TEMPLATE/tache-technique.yml
@@ -20,3 +20,4 @@ body:
       description: Explique brievement la tâche technique
     validations:
       required: true
+


### PR DESCRIPTION
Rename du fichier tâche-technique.yml en tache-technique.yml car le â n'était pas pris en compte lors de la récupération des templates Github et celui-ci ignorait le contenu de ce script lors de la création d'une issue tâche technique.