### PR TITLE
ci(deploy): script no such file fixing

### DIFF
--- a/.github/workflows/deploy-pipelines.yml
+++ b/.github/workflows/deploy-pipelines.yml
@@ -20,10 +20,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ env.NODE_VERSION }}
-    - name: npm install, build, and test
+    - name: npm install and build the frontend
+      working-directory: 'frontend/'
       run: |
-        npm prune --production
-        npm install
+        npm install --omit=dev
         npm run build --if-present
     - name: 'Deploy to Azure WebApp'
       uses: azure/webapps-deploy@v2


### PR DESCRIPTION
Suppresion du npm prune car il est déprécié et est remplacé par l'argument '--omit=dev'.
Ajout du working directory lors du npm install et build car le runner ne trouvait pas le fichier package.json dans le dossier root.