### PR TITLE
ci(deploy): artifact zipping before upload

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -25,6 +25,9 @@ jobs:
           npm run build --if-present
           npm run test --if-present
 
+      - name: Zip artifact for deployment
+        run: zip release.zip ./* -r
+
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v2
         with:
@@ -43,6 +46,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: node-app
+          
+      - name: unzip artifact for deployment
+        run: unzip release.zip
 
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp


### PR DESCRIPTION
Conversion vers Zip avant d'upload l'artifact pour accélerer le temps d'upload.
Ancien temps build : 33 minutes
Ancien temps deploy : 27 minutes
![image](https://user-images.githubusercontent.com/71312500/216115300-1ae4b48d-2827-4a2f-848e-573f61c4f6cb.png)
